### PR TITLE
XMOS FW upgrade issue

### DIFF
--- a/controller/app/cmdline/src/cmd_line.cpp
+++ b/controller/app/cmdline/src/cmd_line.cpp
@@ -153,10 +153,22 @@ int cmd_line::print_interfaces_and_select(char * interface)
 
     for (uint32_t i = 1; i < netif->devs_count() + 1; i++)
     {
-        char * dev_desc = netif->get_dev_desc_by_index(i - 1);
+        size_t dev_index = i - 1;
+        char * dev_desc = netif->get_dev_desc_by_index(dev_index);
         if (!interface)
         {
-            printf("%d (%s)\n", i, dev_desc);
+            printf("%d (%s)", i, dev_desc);
+            size_t ip_addr_count = netif->device_ip_address_count(dev_index);
+            if (ip_addr_count > 0)
+            {
+                for(size_t ip_index = 0; ip_index < ip_addr_count; ip_index++)
+                {
+                    std::string dev_ip = netif->get_dev_ip_address_by_index(dev_index, ip_index);
+                    if (!dev_ip.empty())
+                        printf(" (%s)", dev_ip.c_str());
+                }
+            }
+            printf("\n");
         }
         else
         {

--- a/controller/app/cmdline/src/cmd_line.cpp
+++ b/controller/app/cmdline/src/cmd_line.cpp
@@ -3829,10 +3829,24 @@ int cmd_line::cmd_set_stream_info(int total_matched, std::vector<cli_argument *>
                 return 0;
             }
         }
+        else if (stream_info_field == "msrp_accumulated_latency")
+        {
+            uint32_t msrp_accumulated_latency = (uint32_t)strtoul(new_stream_info_field_value.c_str(), NULL, 0);
+            intptr_t cmd_notification_id = get_next_notification_id();
+            sys->set_wait_for_next_cmd((void *)cmd_notification_id);
+            avdecc_lib::stream_output_descriptor * stream_output_desc_ref = configuration->get_stream_output_desc_by_index(desc_index);
+            stream_output_desc_ref->send_set_stream_info_msrp_accumulated_latency_cmd((void *)cmd_notification_id, msrp_accumulated_latency);
+            int status = sys->get_last_resp_status();
+            if (status != avdecc_lib::AEM_STATUS_SUCCESS)
+            {
+                atomic_cout << "cmd_set_stream_info error" << std::endl;
+                return 0;
+            }
+        }
         else
         {
             atomic_cout << "Supported fields are:" << std::endl
-                        << "stream_vlan_id" << std::endl;
+                        << "stream_vlan_id, msrp_accumulated_latency" << std::endl;
         }
     }
     else

--- a/controller/app/cmdline/src/cmd_line.cpp
+++ b/controller/app/cmdline/src/cmd_line.cpp
@@ -158,6 +158,16 @@ int cmd_line::print_interfaces_and_select(char * interface)
         if (!interface)
         {
             printf("%d (%s)", i, dev_desc);
+            
+            uint64_t dev_mac = netif->get_dev_mac_addr_by_index(dev_index);
+            if (dev_mac)
+            {
+                avdecc_lib::utility::MacAddr mac(dev_mac);
+                char mac_str[20];
+                mac.tostring(mac_str);
+                printf(" (%s)", mac_str);
+            }
+            
             size_t ip_addr_count = netif->device_ip_address_count(dev_index);
             if (ip_addr_count > 0)
             {
@@ -165,17 +175,33 @@ int cmd_line::print_interfaces_and_select(char * interface)
                 {
                     const char * dev_ip = netif->get_dev_ip_address_by_index(dev_index, ip_index);
                     if (dev_ip)
-                        printf(" (%s)", dev_ip);
+                        printf(" <%s>", dev_ip);
                 }
             }
             printf("\n");
         }
         else
         {
-            if (strcmp(dev_desc, interface) == 0)
+            // try to find the selected interface by ip address
+            if (netif->find_selected_interface_by_ip_address(dev_index, interface))
             {
                 interface_num = i;
                 break;
+            }
+
+            // try to find the selected interface by MAC address
+            avdecc_lib::utility::MacAddr mac(interface);
+            if (mac.fromstring(interface)) // valid format? (xx:xx:...)
+            {
+                uint64_t mac_val = mac.tovalue();
+                if (mac_val)
+                {
+                    if (netif->find_selected_interface_by_mac_address(dev_index, mac_val))
+                    {
+                        interface_num = i;
+                        break;
+                    }
+                }
             }
         }
     }
@@ -185,7 +211,26 @@ int cmd_line::print_interfaces_and_select(char * interface)
         atomic_cout << "Enter the interface number (1-" << std::dec << netif->devs_count() << "): ";
         std::cin >> interface_num;
     }
+    else
+    {
+        // if the interface was not found by IP Address or MAC address...
+        if (interface_num == -1)
+        {
+            // treat the selected interface as an index
+            char * tmp;
+            long if_num = strtol(interface, &tmp, 10);
+            if (interface != tmp)
+                interface_num = if_num;
+        }
+    }
 
+    if (interface_num == -1 ||
+        interface_num > netif->devs_count() + 1)
+    {
+        printf("Invalid Interface: (%s).  Exiting...\n", interface);
+        exit(EXIT_FAILURE);
+    }
+    
     netif->select_interface_by_num(interface_num);
 
     return 0;

--- a/controller/app/cmdline/src/cmd_line.cpp
+++ b/controller/app/cmdline/src/cmd_line.cpp
@@ -183,7 +183,7 @@ int cmd_line::print_interfaces_and_select(char * interface)
         else
         {
             // try to find the selected interface by ip address
-            if (netif->find_selected_interface_by_ip_address(dev_index, interface))
+            if (netif->does_interface_have_ip_address(dev_index, interface))
             {
                 interface_num = i;
                 break;
@@ -196,7 +196,7 @@ int cmd_line::print_interfaces_and_select(char * interface)
                 uint64_t mac_val = mac.tovalue();
                 if (mac_val)
                 {
-                    if (netif->find_selected_interface_by_mac_address(dev_index, mac_val))
+                    if (netif->does_interface_have_mac_address(dev_index, mac_val))
                     {
                         interface_num = i;
                         break;

--- a/controller/app/cmdline/src/cmd_line.cpp
+++ b/controller/app/cmdline/src/cmd_line.cpp
@@ -163,9 +163,9 @@ int cmd_line::print_interfaces_and_select(char * interface)
             {
                 for(size_t ip_index = 0; ip_index < ip_addr_count; ip_index++)
                 {
-                    std::string dev_ip = netif->get_dev_ip_address_by_index(dev_index, ip_index);
-                    if (!dev_ip.empty())
-                        printf(" (%s)", dev_ip.c_str());
+                    const char * dev_ip = netif->get_dev_ip_address_by_index(dev_index, ip_index);
+                    if (dev_ip)
+                        printf(" (%s)", dev_ip);
                 }
             }
             printf("\n");

--- a/controller/app/cmdline/src/cmd_line.h
+++ b/controller/app/cmdline/src/cmd_line.h
@@ -440,6 +440,11 @@ private:
     int cmd_set_path(int total_matched, std::vector<cli_argument *> args);
 
     ///
+    /// Get the connection status of an end station
+    ///
+    int cmd_get_connection_status(int total_matched, std::vector<cli_argument *> args);
+    
+    ///
     /// Clear the screen.
     ///
     int cmd_clr(int total_matched, std::vector<cli_argument *> args);

--- a/controller/app/cmdline/src/cmd_line.h
+++ b/controller/app/cmdline/src/cmd_line.h
@@ -59,6 +59,7 @@ public:
     {
         // Use printf as cout seems to still be interleaved
         printf("%s", buffer.str().c_str());
+        fflush(stdout);
     }
 
 private:

--- a/controller/app/cmdline/src/cmd_line_main.cpp
+++ b/controller/app/cmdline/src/cmd_line_main.cpp
@@ -102,6 +102,8 @@ extern "C" void notification_callback(void * user_obj, int32_t notification_type
                cmd_status,
                notification_id);
     }
+    
+    fflush(stdout);
 }
 
 extern "C" void acmp_notification_callback(void * user_obj, int32_t notification_type, uint16_t cmd_type,
@@ -135,11 +137,15 @@ extern "C" void acmp_notification_callback(void * user_obj, int32_t notification
                cmd_status_name,
                notification_id);
     }
+    
+    fflush(stdout);
 }
 
 extern "C" void log_callback(void * user_obj, int32_t log_level, const char * log_msg, int32_t time_stamp_ms)
 {
     printf("\n[LOG] %s (%s)\n", avdecc_lib::utility::logging_level_value_to_name(log_level), log_msg);
+    
+    fflush(stdout);
 }
 
 #if defined(__MACH__) || defined(__linux__)

--- a/controller/app/cmdline/src/cmd_line_main.cpp
+++ b/controller/app/cmdline/src/cmd_line_main.cpp
@@ -292,13 +292,14 @@ static void usage(char * argv[])
 
 int main(int argc, char * argv[])
 {
+    bool show_cmd_separator = false;
     bool test_mode = false;
     int error = 0;
     char * interface = NULL;
     int c = 0;
     int32_t log_level = avdecc_lib::LOGGING_LEVEL_ERROR;
 
-    while ((c = getopt(argc, argv, "pti:l:")) != -1)
+    while ((c = getopt(argc, argv, "spti:l:")) != -1)
     {
         switch (c)
         {
@@ -306,6 +307,9 @@ int main(int argc, char * argv[])
             // print the network interfaces and exit
             print_interfaces();
             exit(EXIT_SUCCESS);
+        case 's':
+            show_cmd_separator = true;
+            break;
         case 't':
             test_mode = true;
             break;
@@ -387,6 +391,8 @@ int main(int argc, char * argv[])
         add_history(input);
 #else
         std::string cmd_input;
+        if (show_cmd_separator)
+            printf("\n_\n");
         printf("\n>");
         std::getline(std::cin, cmd_input);
         cmd_input_orig = cmd_input;

--- a/controller/lib/include/controller.h
+++ b/controller/lib/include/controller.h
@@ -58,6 +58,11 @@ public:
     /// \return The total number of End Stations connected.
     ///
     AVDECC_CONTROLLER_LIB32_API virtual size_t STDCALL get_end_station_count() = 0;
+    
+    ///
+    /// \return The entity id of the controller.
+    ///
+    AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_entity_id() = 0;
 
     ///
     /// \return The corresponding End Station by index.

--- a/controller/lib/include/descriptor_base.h
+++ b/controller/lib/include/descriptor_base.h
@@ -52,6 +52,17 @@ public:
     /// \return The index of the descriptor.
     ///
     AVDECC_CONTROLLER_LIB32_API virtual uint16_t STDCALL descriptor_index() const = 0;
+    
+    ///
+    /// Check the descriptor's permission status.
+    ///
+    /// \param flag The LOCK_ENTITY or ACQUIRE_ENTITY flag to retrieve.
+    /// \see avdecc_lib::permission_flags
+    ///
+    /// \return True if the current permission status matches the flag.
+    ///         False if the current permission status differs.
+    ///
+    AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL get_permission(int flag) = 0;
 
     ///
     /// \return The number of fields in the descriptor.

--- a/controller/lib/include/descriptor_base.h
+++ b/controller/lib/include/descriptor_base.h
@@ -63,6 +63,14 @@ public:
     ///         False if the current permission status differs.
     ///
     AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL get_permission(int flag) = 0;
+    
+    ///
+    /// Get the entity id of the owning controller.
+    ///
+    /// \return The guid of the owning Controller.
+    ///         0 if the entity is neither locked nor acquired.
+    ///
+    AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_owning_guid() = 0;
 
     ///
     /// \return The number of fields in the descriptor.

--- a/controller/lib/include/enumeration.h
+++ b/controller/lib/include/enumeration.h
@@ -302,6 +302,13 @@ enum logging_levels
     LOGGING_LEVEL_VERBOSE = 5,
     TOTAL_NUM_OF_LOGGING_LEVELS = 6
 };
+    
+enum permission_flags /// LOCK_ENTITY and ACQUIRE_ENTITY Flags
+{
+     LOCK,
+     ACQUIRE,
+     PERSISTENT
+};
 
 enum counter_labels ///Counter Labels for GET_COUNTERS command
 {

--- a/controller/lib/include/net_interface.h
+++ b/controller/lib/include/net_interface.h
@@ -75,14 +75,20 @@ public:
     AVDECC_CONTROLLER_LIB32_API virtual char * STDCALL get_dev_name_by_index(size_t dev_index) = 0;
     
     ///
+    /// \param dev_index The index of a network interface.
+    /// \param ip_addr_str The IP Address to check for.
+    ///
     /// \return True if ip_addr_str is the IP address of the device specified by dev_index.
     ///
-    AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL find_selected_interface_by_ip_address(size_t dev_index, char * ip_addr_str) = 0;
+    AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL does_interface_have_ip_address(size_t dev_index, char * ip_addr_str) = 0;
     
+    ///
+    /// \param dev_index The index of a network interface.
+    /// \param mac_addr The MAC address to check for.
     ///
     /// \return True if mac_addr is the MAC address of the device specified by dev_index.
     ///
-    AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL find_selected_interface_by_mac_address(size_t dev_index, uint64_t mac_addr) = 0;
+    AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL does_interface_have_mac_address(size_t dev_index, uint64_t mac_addr) = 0;
 
     ///
     /// Select the corresponding interface by number.

--- a/controller/lib/include/net_interface.h
+++ b/controller/lib/include/net_interface.h
@@ -62,12 +62,27 @@ public:
     /// \return The network interface IP address by index for a device.
     ///
     AVDECC_CONTROLLER_LIB32_API virtual const char * STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index) = 0;
+    
+    ///
+    /// \return The network interface MAC address by index for a device.
+    ///
+    AVDECC_CONTROLLER_LIB32_API virtual uint64_t STDCALL get_dev_mac_addr_by_index(size_t dev_index) = 0;
 
     /// This function is OS dependant. In linux and OSX the return is the same as for a call to
     /// get_dev_desc_by_index(). In Windows this function returns a GUID as a string.
     /// \return The corresponding network interface name by index.
     ///
     AVDECC_CONTROLLER_LIB32_API virtual char * STDCALL get_dev_name_by_index(size_t dev_index) = 0;
+    
+    ///
+    /// \return True if ip_addr_str is the IP address of the device specified by dev_index.
+    ///
+    AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL find_selected_interface_by_ip_address(size_t dev_index, char * ip_addr_str) = 0;
+    
+    ///
+    /// \return True if mac_addr is the MAC address of the device specified by dev_index.
+    ///
+    AVDECC_CONTROLLER_LIB32_API virtual bool STDCALL find_selected_interface_by_mac_address(size_t dev_index, uint64_t mac_addr) = 0;
 
     ///
     /// Select the corresponding interface by number.

--- a/controller/lib/include/net_interface.h
+++ b/controller/lib/include/net_interface.h
@@ -61,7 +61,7 @@ public:
     ///
     /// \return The network interface IP address by index for a device.
     ///
-    AVDECC_CONTROLLER_LIB32_API virtual std::string STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index) = 0;
+    AVDECC_CONTROLLER_LIB32_API virtual const char * STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index) = 0;
 
     /// This function is OS dependant. In linux and OSX the return is the same as for a call to
     /// get_dev_desc_by_index(). In Windows this function returns a GUID as a string.

--- a/controller/lib/include/net_interface.h
+++ b/controller/lib/include/net_interface.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <string>
 #include "avdecc-lib_build.h"
 
 namespace avdecc_lib
@@ -46,11 +47,21 @@ public:
     /// \return The number of devices.
     ///
     AVDECC_CONTROLLER_LIB32_API virtual uint32_t STDCALL devs_count() = 0;
+    
+    ///
+    /// \return The number of IP addresses for a device.
+    ///
+    AVDECC_CONTROLLER_LIB32_API virtual size_t STDCALL device_ip_address_count(size_t dev_index) = 0;
 
     ///
     /// \return The corresponding network interface description by index.
     ///
     AVDECC_CONTROLLER_LIB32_API virtual char * STDCALL get_dev_desc_by_index(size_t dev_index) = 0;
+    
+    ///
+    /// \return The network interface IP address by index for a device.
+    ///
+    AVDECC_CONTROLLER_LIB32_API virtual std::string STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index) = 0;
 
     /// This function is OS dependant. In linux and OSX the return is the same as for a call to
     /// get_dev_desc_by_index(). In Windows this function returns a GUID as a string.

--- a/controller/lib/include/stream_output_descriptor.h
+++ b/controller/lib/include/stream_output_descriptor.h
@@ -101,6 +101,14 @@ public:
     /// \param new_stream_info_field The new field information to be set to for a stream.
     ///
     AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_set_stream_info_vlan_id_cmd(void * notification_id, uint16_t vlan_id) = 0;
+    
+    ///
+    /// Send a SET_STREAM_INFO command with a notification id to set the msrp accumulated latency of the stream.
+    ///
+    /// \param notification_id A void pointer to the unique identifier associated with the command.
+    /// \param msrp_accumulated_latency The new msrp_accumulated_latency (ns) to be set.
+    ///
+    AVDECC_CONTROLLER_LIB32_API virtual int STDCALL send_set_stream_info_msrp_accumulated_latency_cmd(void * notification_id, uint32_t msrp_accumulated_latency) = 0;
 
     ///
     /// Send a GET_STREAM_INFO command with a notification id to fetch the current information for a stream.

--- a/controller/lib/include/util.h
+++ b/controller/lib/include/util.h
@@ -170,6 +170,7 @@ namespace utility
                                     byte6((mac_val & 0XFF)) {}
         MacAddr(const char * p) { fromstring(p); }
 
+        uint64_t tovalue();
         void tostring(char * p, char d = ':') const;
         bool fromstring(const char * p);
 
@@ -267,6 +268,14 @@ namespace utility
         if (i < 6)
             valid = false;
         return valid;
+    }
+    inline uint64_t MacAddr::tovalue()
+    {
+        uint64_t mac_val = 0;
+        for (int i = 0; i < 6; i++)
+            mac_val = uint64_t(getByte(i)) << (40 - (8 * i)) | mac_val;
+        
+        return mac_val;
     }
     inline void MacAddr::tostring(char * p, char d) const
     {

--- a/controller/lib/src/acmp_controller_state_machine.cpp
+++ b/controller/lib/src/acmp_controller_state_machine.cpp
@@ -294,13 +294,13 @@ int acmp_controller_state_machine::callback(void * notification_id, uint32_t not
         if (status != ACMP_STATUS_SUCCESS)
         {
             log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR,
-                                      "RESPONSE_RECEIVED, 0x%llx, %s, %s, %s, %s, %d",
+                                      "RESPONSE_RECEIVED, 0x%llx, %s, %s, %s, %d, %s",
                                       end_station_entity_id,
                                       utility::acmp_cmd_value_to_name(msg_type),
                                       "NULL",
                                       "NULL",
-                                      utility::acmp_cmd_status_value_to_name(status),
-                                      seq_id);
+                                      seq_id,
+                                      utility::acmp_cmd_status_value_to_name(status));
         }
     }
     else if ((notification_flag == CMD_WITH_NOTIFICATION) &&
@@ -336,13 +336,13 @@ int acmp_controller_state_machine::callback(void * notification_id, uint32_t not
         if (status != ACMP_STATUS_SUCCESS)
         {
             log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR,
-                                      "RESPONSE_RECEIVED, 0x%llx, %s, %s, %s, %s, %d",
+                                      "RESPONSE_RECEIVED, 0x%llx, %s, %s, %s, %d, %s",
                                       end_station_entity_id,
                                       utility::acmp_cmd_value_to_name(msg_type),
                                       "NULL",
                                       "NULL",
-                                      utility::acmp_cmd_status_value_to_name(status),
-                                      seq_id);
+                                      seq_id,
+                                      utility::acmp_cmd_status_value_to_name(status));
         }
     }
     else if ((notification_flag == CMD_WITHOUT_NOTIFICATION) &&
@@ -400,13 +400,13 @@ int acmp_controller_state_machine::callback(void * notification_id, uint32_t not
         struct jdksavdecc_eui64 _end_station_entity_id = jdksavdecc_acmpdu_get_listener_entity_id(frame, ETHER_HDR_SIZE);
         end_station_entity_id = jdksavdecc_uint64_get(&_end_station_entity_id, 0);
         log_imp_ref->post_log_msg(LOGGING_LEVEL_DEBUG,
-                                  "COMMAND_SENT, 0x%llx, %s, %s, %s, %s, %d",
+                                  "COMMAND_SENT, 0x%llx, %s, %s, %s, %d, %s",
                                   end_station_entity_id,
                                   utility::acmp_cmd_value_to_name(msg_type),
                                   "NULL",
                                   "NULL",
-                                  utility::acmp_cmd_status_value_to_name(status),
-                                  seq_id);
+                                  seq_id,
+                                  utility::acmp_cmd_status_value_to_name(status));
     }
 
     return 0;

--- a/controller/lib/src/adp.h
+++ b/controller/lib/src/adp.h
@@ -82,11 +82,9 @@ public:
     ///
     /// Get the Controller Entity ID of the AVDECC Entity sending the command.
     ///
-    /// This function is used by descriptor commands to fetch the
-    /// controller entity id corresponding to a particular end station.
-    /// A copy of this function that bypasses
-    /// the adp and end_station classes exists in controller.h.
+    /// This function converts the net_interface_imp mac address to the controller entity id.
     ///
+    /// A copy of this function exists in controller.h
     /// \see get_entity_id()
     ///
     static struct jdksavdecc_eui64 get_controller_entity_id();

--- a/controller/lib/src/adp.h
+++ b/controller/lib/src/adp.h
@@ -82,6 +82,13 @@ public:
     ///
     /// Get the Controller Entity ID of the AVDECC Entity sending the command.
     ///
+    /// This function is used by descriptor commands to fetch the
+    /// controller entity id corresponding to a particular end station.
+    /// A copy of this function that bypasses
+    /// the adp and end_station classes exists in controller.h.
+    ///
+    /// \see get_entity_id()
+    ///
     static struct jdksavdecc_eui64 get_controller_entity_id();
 
     ///

--- a/controller/lib/src/controller_imp.cpp
+++ b/controller/lib/src/controller_imp.cpp
@@ -172,6 +172,15 @@ size_t STDCALL controller_imp::get_end_station_count()
 {
     return end_station_array->size();
 }
+    
+uint64_t STDCALL controller_imp::get_entity_id()
+{
+    uint64_t controller_entity_id = ((net_interface_ref->mac_addr() & UINT64_C(0xFFFFFF000000)) << 16) |
+                                    UINT64_C(0x000000FFFF000000) |
+                                    (net_interface_ref->mac_addr() & UINT64_C(0xFFFFFF));
+    
+    return controller_entity_id;
+}
 
 end_station * STDCALL controller_imp::get_end_station_by_index(size_t end_station_index)
 {

--- a/controller/lib/src/controller_imp.h
+++ b/controller/lib/src/controller_imp.h
@@ -67,9 +67,9 @@ public:
     const char * STDCALL get_version() const;
 
     ///
-    /// This function is included to bypass the
-    /// adp.h function used by descriptor commands.
+    /// This function converts the net_interface_imp mac address to the controller entity id.
     ///
+    /// A copy of this function exists in adp.h
     /// \see get_controller_entity_id()
     uint64_t STDCALL get_entity_id();
     size_t STDCALL get_end_station_count();

--- a/controller/lib/src/controller_imp.h
+++ b/controller/lib/src/controller_imp.h
@@ -65,6 +65,13 @@ public:
     void STDCALL destroy();
 
     const char * STDCALL get_version() const;
+
+    ///
+    /// This function is included to bypass the
+    /// adp.h function used by descriptor commands.
+    ///
+    /// \see get_controller_entity_id()
+    uint64_t STDCALL get_entity_id();
     size_t STDCALL get_end_station_count();
     end_station * STDCALL get_end_station_by_index(size_t end_station_index);
 

--- a/controller/lib/src/descriptor_base_imp.cpp
+++ b/controller/lib/src/descriptor_base_imp.cpp
@@ -110,6 +110,11 @@ bool STDCALL descriptor_base_imp::get_permission(int flag)
         return false;
     }
 }
+    
+uint64_t STDCALL descriptor_base_imp::get_owning_guid()
+{
+    return owning_guid;
+}
 
 uint16_t STDCALL descriptor_base_imp::descriptor_type() const
 {
@@ -238,6 +243,7 @@ int descriptor_base_imp::default_proc_acquire_entity_resp(struct jdksavdecc_aem_
     u_field = aem_cmd_acquire_entity_resp.aem_header.command_type >> 15 & 0x01; // u_field = the msb of the uint16_t command_type
 
     last_rcvd_acquire_entity_flags = aem_cmd_acquire_entity_resp.aem_acquire_flags;
+    owning_guid = jdksavdecc_eui64_convert_to_uint64(&aem_cmd_acquire_entity_resp.owner_entity_id);
 
     aecp_controller_state_machine_ref->update_inflight_for_rcvd_resp(notification_id, msg_type, u_field, &cmd_frame);
 
@@ -338,6 +344,7 @@ int descriptor_base_imp::default_proc_lock_entity_resp(struct jdksavdecc_aem_com
     u_field = aem_cmd_lock_entity_resp.aem_header.command_type >> 15 & 0x01; // u_field = the msb of the uint16_t command_type
     
     last_rcvd_lock_entity_flags = aem_cmd_lock_entity_resp.aem_lock_flags;
+    owning_guid = jdksavdecc_eui64_convert_to_uint64(&aem_cmd_lock_entity_resp.locked_entity_id);
     
     aecp_controller_state_machine_ref->update_inflight_for_rcvd_resp(notification_id, msg_type, u_field, &cmd_frame);
 

--- a/controller/lib/src/descriptor_base_imp.h
+++ b/controller/lib/src/descriptor_base_imp.h
@@ -56,7 +56,22 @@ protected:
     response_frame * resp_ref;
     uint16_t desc_type;
     uint16_t desc_index;
-
+    
+    ///
+    /// Store the lock status - the last received lock entity flags.
+    /// This is not guaranteed to be the actual status as another
+    /// controller may have locked the Entity before this controller
+    /// is notified of the change.
+    ///
+    uint32_t last_rcvd_lock_entity_flags = 0x1; // initialized to unlocked
+    
+    ///
+    /// Store the acquire status - the last received acquire entity flags.
+    /// This is not guaranteed to be the actual status as another
+    /// controller may have acquired the Entity before this controller
+    /// is notified of the change.
+    ///
+    uint32_t last_rcvd_acquire_entity_flags = 0x80000000; // initialized to released
 public:
     descriptor_base_imp(end_station_imp * base, const uint8_t * frame, size_t size, ssize_t pos);
     virtual ~descriptor_base_imp();
@@ -64,6 +79,7 @@ public:
     uint16_t STDCALL descriptor_type() const;
     uint16_t STDCALL descriptor_index() const;
     virtual uint16_t STDCALL localized_description();
+    bool STDCALL get_permission(int flag);
 
     size_t STDCALL field_count() const
     {

--- a/controller/lib/src/descriptor_base_imp.h
+++ b/controller/lib/src/descriptor_base_imp.h
@@ -72,6 +72,14 @@ protected:
     /// is notified of the change.
     ///
     uint32_t last_rcvd_acquire_entity_flags = 0x80000000; // initialized to released
+    
+    ///
+    /// Store the owning guid - the last received acquire or lock owner.
+    /// This is not guaranteed to be the actual owner as another
+    /// controller may have locked or acquired the Entity before this controller
+    /// is notified of the change.
+    ///
+    uint64_t owning_guid = 0;
 public:
     descriptor_base_imp(end_station_imp * base, const uint8_t * frame, size_t size, ssize_t pos);
     virtual ~descriptor_base_imp();
@@ -80,6 +88,7 @@ public:
     uint16_t STDCALL descriptor_index() const;
     virtual uint16_t STDCALL localized_description();
     bool STDCALL get_permission(int flag);
+    uint64_t STDCALL get_owning_guid();
 
     size_t STDCALL field_count() const
     {

--- a/controller/lib/src/linux/net_interface_imp.cpp
+++ b/controller/lib/src/linux/net_interface_imp.cpp
@@ -149,6 +149,12 @@ uint32_t STDCALL net_interface_imp::devs_count()
     return total_devs;
 }
 
+size_t STDCALL net_interface_imp::device_ip_address_count(size_t dev_index)
+{
+    // need to implement
+    return -1;
+}
+
 uint64_t net_interface_imp::mac_addr()
 {
     return mac;
@@ -162,6 +168,12 @@ char * STDCALL net_interface_imp::get_dev_desc_by_index(size_t dev_index)
 char * STDCALL net_interface_imp::get_dev_name_by_index(size_t dev_index)
 {
     return get_dev_desc_by_index(dev_index);
+}
+    
+std::string STDCALL net_interface_imp::get_dev_ip_address_by_index(size_t dev_index, size_t ip_index)
+{
+    // need to implement
+    return "";
 }
 
 int net_interface_imp::get_fd()

--- a/controller/lib/src/linux/net_interface_imp.cpp
+++ b/controller/lib/src/linux/net_interface_imp.cpp
@@ -143,6 +143,24 @@ void STDCALL net_interface_imp::destroy()
 {
     delete this;
 }
+    
+bool STDCALL net_interface_imp::find_selected_interface_by_ip_address(size_t dev_index, char * ip_addr_str)
+{
+    // need to implement
+    return false;
+}
+
+bool STDCALL net_interface_imp::find_selected_interface_by_mac_address(size_t dev_index, uint64_t mac_addr)
+{
+    // need to implement
+    return false;
+}
+
+uint64_t net_interface_imp::get_dev_mac_addr_by_index(size_t dev_index)
+{
+    //need to implement
+    return 0;
+}
 
 uint32_t STDCALL net_interface_imp::devs_count()
 {

--- a/controller/lib/src/linux/net_interface_imp.cpp
+++ b/controller/lib/src/linux/net_interface_imp.cpp
@@ -144,13 +144,13 @@ void STDCALL net_interface_imp::destroy()
     delete this;
 }
     
-bool STDCALL net_interface_imp::find_selected_interface_by_ip_address(size_t dev_index, char * ip_addr_str)
+bool STDCALL net_interface_imp::does_interface_have_ip_address(size_t dev_index, char * ip_addr_str)
 {
     // need to implement
     return false;
 }
 
-bool STDCALL net_interface_imp::find_selected_interface_by_mac_address(size_t dev_index, uint64_t mac_addr)
+bool STDCALL net_interface_imp::does_interface_have_mac_address(size_t dev_index, uint64_t mac_addr)
 {
     // need to implement
     return false;

--- a/controller/lib/src/linux/net_interface_imp.cpp
+++ b/controller/lib/src/linux/net_interface_imp.cpp
@@ -151,7 +151,7 @@ uint32_t STDCALL net_interface_imp::devs_count()
 
 size_t STDCALL net_interface_imp::device_ip_address_count(size_t dev_index)
 {
-    // not needed
+    // not needed on this platform as the device IP is embedded in the string returned by get_dev_desc_by_index()
     return -1;
 }
 
@@ -172,7 +172,7 @@ char * STDCALL net_interface_imp::get_dev_name_by_index(size_t dev_index)
     
 const char * STDCALL net_interface_imp::get_dev_ip_address_by_index(size_t dev_index, size_t ip_index)
 {
-    // not needed
+    // not needed on this platform as the device IP is embedded in the string returned by get_dev_desc_by_index()
     return NULL;
 }
 

--- a/controller/lib/src/linux/net_interface_imp.cpp
+++ b/controller/lib/src/linux/net_interface_imp.cpp
@@ -151,7 +151,7 @@ uint32_t STDCALL net_interface_imp::devs_count()
 
 size_t STDCALL net_interface_imp::device_ip_address_count(size_t dev_index)
 {
-    // need to implement
+    // not needed
     return -1;
 }
 
@@ -170,10 +170,10 @@ char * STDCALL net_interface_imp::get_dev_name_by_index(size_t dev_index)
     return get_dev_desc_by_index(dev_index);
 }
     
-std::string STDCALL net_interface_imp::get_dev_ip_address_by_index(size_t dev_index, size_t ip_index)
+const char * STDCALL net_interface_imp::get_dev_ip_address_by_index(size_t dev_index, size_t ip_index)
 {
-    // need to implement
-    return "";
+    // not needed
+    return NULL;
 }
 
 int net_interface_imp::get_fd()

--- a/controller/lib/src/linux/net_interface_imp.h
+++ b/controller/lib/src/linux/net_interface_imp.h
@@ -112,12 +112,12 @@ public:
     ///
     /// Check whether ip_addr_str is a valid IP Address for a device.
     ///
-    bool STDCALL find_selected_interface_by_ip_address(size_t dev_index, char * ip_addr_str);
+    bool STDCALL does_interface_have_ip_address(size_t dev_index, char * ip_addr_str);
     
     ///
     /// Check whether mac_addr is the MAC Address for a device.
     ///
-    bool STDCALL find_selected_interface_by_mac_address(size_t dev_index, uint64_t mac_addr);
+    bool STDCALL does_interface_have_mac_address(size_t dev_index, uint64_t mac_addr);
 
     ///
     /// Get the corresponding network interface name by index.

--- a/controller/lib/src/linux/net_interface_imp.h
+++ b/controller/lib/src/linux/net_interface_imp.h
@@ -83,6 +83,11 @@ public:
     /// Count the number of devices.
     ///
     uint32_t STDCALL devs_count();
+    
+    ///
+    /// Count the number of IP addresses for a device.
+    ///
+    size_t STDCALL device_ip_address_count(size_t dev_index);
 
     ///
     /// Get the MAC address of the network interface.
@@ -93,6 +98,11 @@ public:
     /// Get network interface description by index.
     ///
     char * STDCALL get_dev_desc_by_index(size_t dev_index);
+
+    ///
+    /// Get the corresponding network interface IP address by index.
+    ///
+    std::string STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index);
 
     ///
     /// Get the corresponding network interface name by index.

--- a/controller/lib/src/linux/net_interface_imp.h
+++ b/controller/lib/src/linux/net_interface_imp.h
@@ -95,6 +95,11 @@ public:
     uint64_t mac_addr();
 
     ///
+    /// Get the MAC address of a network interface.
+    ///
+    uint64_t STDCALL get_dev_mac_addr_by_index(size_t dev_index);
+
+    ///
     /// Get network interface description by index.
     ///
     char * STDCALL get_dev_desc_by_index(size_t dev_index);
@@ -103,6 +108,16 @@ public:
     /// Get the corresponding network interface IP address by index.
     ///
     const char * STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index);
+    
+    ///
+    /// Check whether ip_addr_str is a valid IP Address for a device.
+    ///
+    bool STDCALL find_selected_interface_by_ip_address(size_t dev_index, char * ip_addr_str);
+    
+    ///
+    /// Check whether mac_addr is the MAC Address for a device.
+    ///
+    bool STDCALL find_selected_interface_by_mac_address(size_t dev_index, uint64_t mac_addr);
 
     ///
     /// Get the corresponding network interface name by index.

--- a/controller/lib/src/linux/net_interface_imp.h
+++ b/controller/lib/src/linux/net_interface_imp.h
@@ -102,7 +102,7 @@ public:
     ///
     /// Get the corresponding network interface IP address by index.
     ///
-    std::string STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index);
+    const char * STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index);
 
     ///
     /// Get the corresponding network interface name by index.

--- a/controller/lib/src/msvc/net_interface_imp.cpp
+++ b/controller/lib/src/msvc/net_interface_imp.cpp
@@ -139,15 +139,15 @@ char * STDCALL net_interface_imp::get_dev_name_by_index(size_t dev_index)
     return dev->name;
 }
     
-std::string STDCALL net_interface_imp::get_dev_ip_address_by_index(size_t dev_index, size_t ip_index)
+const char * STDCALL net_interface_imp::get_dev_ip_address_by_index(size_t dev_index, size_t ip_index)
 {
     if (dev_index < all_ip_addresses.size())
     {
         if (ip_index < all_ip_addresses.at(dev_index).size())
-            return all_ip_addresses.at(dev_index).at(ip_index);
+            return all_ip_addresses.at(dev_index).at(ip_index).c_str();
     }
     
-    return "";
+    return NULL;
 }
 
 int STDCALL net_interface_imp::select_interface_by_num(uint32_t interface_num)

--- a/controller/lib/src/msvc/net_interface_imp.cpp
+++ b/controller/lib/src/msvc/net_interface_imp.cpp
@@ -62,24 +62,62 @@ net_interface_imp::net_interface_imp()
             {
                 if (dev_addr->addr->sa_family == AF_INET && dev_addr->addr)
                 {
-                    char ip_str[INET_ADDRSTRLEN] = {0};
-                    struct sockaddr_in * sa = (struct sockaddr_in *)dev_addr->addr;
-                    inet_ntop(AF_INET, &sa->sin_addr, ip_str, INET_ADDRSTRLEN);
+                    char ip_str[INET_ADDRSTRLEN] = { 0 };
+                    inet_ntop(AF_INET, &((struct sockaddr_in *)dev_addr->addr)->sin_addr, ip_str, INET_ADDRSTRLEN);
                     device_ip_addresses.push_back(std::string(ip_str));
-                    
-                    uint64_t dev_mac;
-                    ULONG len;
-                    uint8_t tmp[16];
-                    len = sizeof(tmp);
-                    SendARP(sa->sin_addr.S_un.S_addr, INADDR_ANY, tmp, &len);
-                    utility::convert_eui48_to_uint64(&tmp[0], dev_mac);
-                    all_mac_addresses.push_back(dev_mac);
                 }
             }
-            
+
             all_ip_addresses.push_back(device_ip_addresses);
             total_devs++;
         }
+
+        /****************************** Find Adapter Info ***************************/
+        IP_ADAPTER_INFO * AdapterInfo;
+        ULONG AIS;
+        DWORD status;
+        AdapterInfo = (IP_ADAPTER_INFO *)calloc(total_devs, sizeof(IP_ADAPTER_INFO));
+        AIS = sizeof(IP_ADAPTER_INFO) * total_devs;
+
+        if (GetAdaptersInfo(AdapterInfo, &AIS) == ERROR_BUFFER_OVERFLOW)
+        {
+            free(AdapterInfo);
+            AdapterInfo = (IP_ADAPTER_INFO *)calloc(1, AIS);
+
+            if (AdapterInfo == NULL)
+            {
+                log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "Allocating memory needed to call GetAdaptersinfo.", dev->name);
+                return;
+            }
+
+            status = GetAdaptersInfo(AdapterInfo, &AIS);
+            if (status != ERROR_SUCCESS)
+            {
+                log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "GetAdaptersInfo call in netif_win32_pcap.c failed.", dev->name);
+                free(AdapterInfo);
+                return;
+            }
+        }
+
+        PIP_ADAPTER_INFO pAdapterInfo = NULL;
+        for (dev = all_devs; dev; dev = dev->next)
+        {
+            uint64_t dev_mac_addr = 0;
+            for (pAdapterInfo = AdapterInfo; pAdapterInfo != NULL; pAdapterInfo = pAdapterInfo->Next)
+            {
+                if (strstr(dev->name, pAdapterInfo->AdapterName) != 0)
+                {
+                    utility::MacAddr mac(
+                                         pAdapterInfo->Address[0], pAdapterInfo->Address[1],
+                                         pAdapterInfo->Address[2], pAdapterInfo->Address[3],
+                                         pAdapterInfo->Address[4], pAdapterInfo->Address[5]);
+                    dev_mac_addr = mac.tovalue();
+                    break;
+                }
+            }
+            all_mac_addresses.push_back(dev_mac_addr);
+        }
+        free(AdapterInfo);
     }
 
     if (total_devs == 0)
@@ -194,17 +232,13 @@ uint64_t net_interface_imp::get_dev_mac_addr_by_index(size_t dev_index)
 int STDCALL net_interface_imp::select_interface_by_num(uint32_t interface_num)
 {
     uint32_t index;
-    IP_ADAPTER_INFO * AdapterInfo;
-    IP_ADAPTER_INFO * Current;
-    ULONG AIS;
-    DWORD status;
     int timeout_ms = NETIF_READ_TIMEOUT_MS;
 
     if (interface_num < 1 || interface_num > total_devs)
     {
         log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "Interface number out of range.");
         pcap_freealldevs(all_devs); // Free the device list
-        exit(EXIT_FAILURE);
+        return -1;
     }
 
     for (dev = all_devs, index = 0; index < interface_num - 1; dev = dev->next, index++)
@@ -221,53 +255,22 @@ int STDCALL net_interface_imp::select_interface_by_num(uint32_t interface_num)
     {
         log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "Unable to open the adapter. %s is not supported by WinPcap.", dev->name);
         pcap_freealldevs(all_devs); // Free the device list
-        exit(EXIT_FAILURE);
+        return -1;
     }
 
-    /****************************** Lookup IP address ***************************/
-    AdapterInfo = (IP_ADAPTER_INFO *)calloc(total_devs, sizeof(IP_ADAPTER_INFO));
-    AIS = sizeof(IP_ADAPTER_INFO) * total_devs;
-
-    if (GetAdaptersInfo(AdapterInfo, &AIS) == ERROR_BUFFER_OVERFLOW)
+    if (index >= all_mac_addresses.size())
     {
-        free(AdapterInfo);
-        AdapterInfo = (IP_ADAPTER_INFO *)calloc(1, AIS);
-
-        if (AdapterInfo == NULL)
-        {
-            log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "Allocating memory needed to call GetAdaptersinfo.", dev->name);
-            exit(EXIT_FAILURE);
-        }
-
-        status = GetAdaptersInfo(AdapterInfo, &AIS);
-
-        if (status != ERROR_SUCCESS)
-        {
-            log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "GetAdaptersInfo call in netif_win32_pcap.c failed.", dev->name);
-            free(AdapterInfo);
-            exit(EXIT_FAILURE);
-        }
+        perror("Cannot find selected interface MAC address");
+        return -1;
     }
-
-    for (Current = AdapterInfo; Current != NULL; Current = Current->Next)
-    {
-        if (strstr(dev->name, Current->AdapterName) != 0)
-        {
-            if (index >= all_mac_addresses.size())
-            {
-                perror("Cannot find selected interface MAC address");
-                exit(EXIT_FAILURE);
-            }
-            
-            selected_dev_mac = all_mac_addresses.at(index);
-        }
-    }
-
+	
+    selected_dev_mac = all_mac_addresses.at(index);
+	
     uint16_t ether_type[1];
     ether_type[0] = JDKSAVDECC_AVTP_ETHERTYPE;
-    set_capture_ether_type(ether_type, 1); // Set the filter
+    if (set_capture_ether_type(ether_type, 1) < 0) // Set the filter
+        return -1;
 
-    free(AdapterInfo);
     return 0;
 }
 

--- a/controller/lib/src/msvc/net_interface_imp.cpp
+++ b/controller/lib/src/msvc/net_interface_imp.cpp
@@ -54,6 +54,20 @@ net_interface_imp::net_interface_imp()
     {
         for (dev = all_devs; dev; dev = dev->next)
         {
+            // store the valid IPv4 addresses associated with the device
+            std::vector<std::string> device_ip_addresses;
+            pcap_addr_t * dev_addr;
+            for (dev_addr = dev->addresses; dev_addr != NULL; dev_addr = dev_addr->next)
+            {
+                if (dev_addr->addr->sa_family == AF_INET && dev_addr->addr)
+                {
+                    char ip_str[INET_ADDRSTRLEN] = {0};
+                    inet_ntop(AF_INET, &((struct sockaddr_in *)dev_addr->addr)->sin_addr, ip_str, INET_ADDRSTRLEN);
+                    device_ip_addresses.push_back(std::string(ip_str));
+                }
+            }
+            
+            all_ip_addresses.push_back(device_ip_addresses);
             total_devs++;
         }
     }
@@ -80,6 +94,14 @@ void STDCALL net_interface_imp::destroy()
 uint32_t STDCALL net_interface_imp::devs_count()
 {
     return total_devs;
+}
+
+size_t STDCALL net_interface_imp::device_ip_address_count(size_t dev_index)
+{
+    if (dev_index < all_ip_addresses.size())
+        return all_ip_addresses.at(dev_index).size();
+
+    return -1;
 }
 
 uint64_t net_interface_imp::mac_addr()
@@ -115,6 +137,17 @@ char * STDCALL net_interface_imp::get_dev_name_by_index(size_t dev_index)
     }
 
     return dev->name;
+}
+    
+std::string STDCALL net_interface_imp::get_dev_ip_address_by_index(size_t dev_index, size_t ip_index)
+{
+    if (dev_index < all_ip_addresses.size())
+    {
+        if (ip_index < all_ip_addresses.at(dev_index).size())
+            return all_ip_addresses.at(dev_index).at(ip_index);
+    }
+    
+    return "";
 }
 
 int STDCALL net_interface_imp::select_interface_by_num(uint32_t interface_num)

--- a/controller/lib/src/msvc/net_interface_imp.cpp
+++ b/controller/lib/src/msvc/net_interface_imp.cpp
@@ -93,7 +93,7 @@ net_interface_imp::net_interface_imp()
             status = GetAdaptersInfo(AdapterInfo, &AIS);
             if (status != ERROR_SUCCESS)
             {
-                log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "GetAdaptersInfo call in netif_win32_pcap.c failed.", dev->name);
+                log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "GetAdaptersInfo call in net_interface_imp.cpp failed.", dev->name);
                 free(AdapterInfo);
                 return;
             }
@@ -260,7 +260,7 @@ int STDCALL net_interface_imp::select_interface_by_num(uint32_t interface_num)
 
     if (index >= all_mac_addresses.size())
     {
-        perror("Cannot find selected interface MAC address");
+        log_imp_ref->post_log_msg(LOGGING_LEVEL_ERROR, "Cannot find selected interface MAC address");
         return -1;
     }
 	

--- a/controller/lib/src/msvc/net_interface_imp.cpp
+++ b/controller/lib/src/msvc/net_interface_imp.cpp
@@ -27,6 +27,7 @@
  * Network interface implementation class
  */
 
+#include <algorithm>
 #include <winsock2.h>
 #include <iphlpapi.h>
 #include "util.h"
@@ -62,8 +63,17 @@ net_interface_imp::net_interface_imp()
                 if (dev_addr->addr->sa_family == AF_INET && dev_addr->addr)
                 {
                     char ip_str[INET_ADDRSTRLEN] = {0};
-                    inet_ntop(AF_INET, &((struct sockaddr_in *)dev_addr->addr)->sin_addr, ip_str, INET_ADDRSTRLEN);
+                    struct sockaddr_in * sa = (struct sockaddr_in *)dev_addr->addr;
+                    inet_ntop(AF_INET, &sa->sin_addr, ip_str, INET_ADDRSTRLEN);
                     device_ip_addresses.push_back(std::string(ip_str));
+                    
+                    uint64_t dev_mac;
+                    ULONG len;
+                    uint8_t tmp[16];
+                    len = sizeof(tmp);
+                    SendARP(sa->sin_addr.S_un.S_addr, INADDR_ANY, tmp, &len);
+                    utility::convert_eui48_to_uint64(&tmp[0], dev_mac);
+                    all_mac_addresses.push_back(dev_mac);
                 }
             }
             
@@ -106,7 +116,7 @@ size_t STDCALL net_interface_imp::device_ip_address_count(size_t dev_index)
 
 uint64_t net_interface_imp::mac_addr()
 {
-    return mac;
+    return selected_dev_mac;
 }
 
 char * STDCALL net_interface_imp::get_dev_desc_by_index(size_t dev_index)
@@ -148,6 +158,37 @@ const char * STDCALL net_interface_imp::get_dev_ip_address_by_index(size_t dev_i
     }
     
     return NULL;
+}
+    
+bool STDCALL net_interface_imp::find_selected_interface_by_ip_address(size_t dev_index, char * ip_addr_str)
+{
+    if (dev_index < all_ip_addresses.size())
+    {
+        if (std::find(all_ip_addresses.at(dev_index).begin(), all_ip_addresses.at(dev_index).end(),
+                      std::string(ip_addr_str)) != all_ip_addresses.at(dev_index).end())
+            return true;
+    }
+    
+    return false;
+}
+
+bool STDCALL net_interface_imp::find_selected_interface_by_mac_address(size_t dev_index, uint64_t mac_addr)
+{
+    if (dev_index < all_mac_addresses.size())
+    {
+        if (all_mac_addresses.at(dev_index) == mac_addr)
+            return true;
+    }
+    
+    return false;
+}
+    
+uint64_t net_interface_imp::get_dev_mac_addr_by_index(size_t dev_index)
+{
+    if (dev_index < all_mac_addresses.size())
+        return all_mac_addresses.at(dev_index);
+    
+    return 0;
 }
 
 int STDCALL net_interface_imp::select_interface_by_num(uint32_t interface_num)
@@ -212,13 +253,13 @@ int STDCALL net_interface_imp::select_interface_by_num(uint32_t interface_num)
     {
         if (strstr(dev->name, Current->AdapterName) != 0)
         {
-            struct sockaddr_in sa;
-            ULONG len;
-            uint8_t tmp[16];
-            inet_pton(AF_INET, Current->IpAddressList.IpAddress.String, &(sa.sin_addr));
-            len = sizeof(tmp);
-            SendARP(sa.sin_addr.S_un.S_addr, INADDR_ANY, tmp, &len);
-            utility::convert_eui48_to_uint64(&tmp[0], mac);
+            if (index >= all_mac_addresses.size())
+            {
+                perror("Cannot find selected interface MAC address");
+                exit(EXIT_FAILURE);
+            }
+            
+            selected_dev_mac = all_mac_addresses.at(index);
         }
     }
 

--- a/controller/lib/src/msvc/net_interface_imp.cpp
+++ b/controller/lib/src/msvc/net_interface_imp.cpp
@@ -160,7 +160,7 @@ const char * STDCALL net_interface_imp::get_dev_ip_address_by_index(size_t dev_i
     return NULL;
 }
     
-bool STDCALL net_interface_imp::find_selected_interface_by_ip_address(size_t dev_index, char * ip_addr_str)
+bool STDCALL net_interface_imp::does_interface_have_ip_address(size_t dev_index, char * ip_addr_str)
 {
     if (dev_index < all_ip_addresses.size())
     {
@@ -172,7 +172,7 @@ bool STDCALL net_interface_imp::find_selected_interface_by_ip_address(size_t dev
     return false;
 }
 
-bool STDCALL net_interface_imp::find_selected_interface_by_mac_address(size_t dev_index, uint64_t mac_addr)
+bool STDCALL net_interface_imp::does_interface_have_mac_address(size_t dev_index, uint64_t mac_addr)
 {
     if (dev_index < all_mac_addresses.size())
     {

--- a/controller/lib/src/msvc/net_interface_imp.cpp
+++ b/controller/lib/src/msvc/net_interface_imp.cpp
@@ -212,13 +212,12 @@ int STDCALL net_interface_imp::select_interface_by_num(uint32_t interface_num)
     {
         if (strstr(dev->name, Current->AdapterName) != 0)
         {
-            uint32_t my_ip;
+            struct sockaddr_in sa;
             ULONG len;
             uint8_t tmp[16];
-
-            my_ip = inet_addr(Current->IpAddressList.IpAddress.String);
+            inet_pton(AF_INET, Current->IpAddressList.IpAddress.String, &(sa.sin_addr));
             len = sizeof(tmp);
-            SendARP(my_ip, INADDR_ANY, tmp, &len);
+            SendARP(sa.sin_addr.S_un.S_addr, INADDR_ANY, tmp, &len);
             utility::convert_eui48_to_uint64(&tmp[0], mac);
         }
     }

--- a/controller/lib/src/msvc/net_interface_imp.h
+++ b/controller/lib/src/msvc/net_interface_imp.h
@@ -43,9 +43,10 @@ class net_interface_imp : public net_interface
 {
 private:
     std::vector<std::vector<std::string> > all_ip_addresses;
+    std::vector<uint64_t> all_mac_addresses;
     pcap_if_t * all_devs;
     pcap_if_t * dev;
-    uint64_t mac;
+    uint64_t selected_dev_mac;
     uint32_t total_devs;
     pcap_t * pcap_interface;
     char err_buf[PCAP_ERRBUF_SIZE];
@@ -73,9 +74,14 @@ public:
     size_t STDCALL device_ip_address_count(size_t dev_index);
 
     ///
-    /// Get the MAC address of the network interface.
+    /// Get the MAC address of the selected network interface.
     ///
     uint64_t mac_addr();
+
+    ///
+    /// Get the MAC address of a network interface.
+    ///
+    uint64_t STDCALL get_dev_mac_addr_by_index(size_t dev_index);
 
     ///
     /// Get the corresponding network interface description by index.
@@ -86,6 +92,16 @@ public:
     /// Get the corresponding network interface IP address by index.
     ///
     const char * STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index);
+    
+    ///
+    /// Check whether ip_addr_str is a valid IP Address for a device.
+    ///
+    bool STDCALL find_selected_interface_by_ip_address(size_t dev_index, char * ip_addr_str);
+    
+    ///
+    /// Check whether mac_addr is the MAC Address for a device.
+    ///
+    bool STDCALL find_selected_interface_by_mac_address(size_t dev_index, uint64_t mac_addr);
 
     ///
     /// Get the corresponding network interface name by index.

--- a/controller/lib/src/msvc/net_interface_imp.h
+++ b/controller/lib/src/msvc/net_interface_imp.h
@@ -85,7 +85,7 @@ public:
     ///
     /// Get the corresponding network interface IP address by index.
     ///
-    std::string STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index);
+    const char * STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index);
 
     ///
     /// Get the corresponding network interface name by index.

--- a/controller/lib/src/msvc/net_interface_imp.h
+++ b/controller/lib/src/msvc/net_interface_imp.h
@@ -32,6 +32,7 @@
 #define HAVE_REMOTE
 
 #include <stdint.h>
+#include <vector>
 #include <pcap.h>
 #include "avdecc-lib_build.h"
 #include "net_interface.h"
@@ -41,6 +42,7 @@ namespace avdecc_lib
 class net_interface_imp : public net_interface
 {
 private:
+    std::vector<std::vector<std::string> > all_ip_addresses;
     pcap_if_t * all_devs;
     pcap_if_t * dev;
     uint64_t mac;
@@ -64,6 +66,11 @@ public:
     /// Count the number of devices.
     ///
     uint32_t STDCALL devs_count();
+    
+    ///
+    /// Count the number of IP addresses for a device.
+    ///
+    size_t STDCALL device_ip_address_count(size_t dev_index);
 
     ///
     /// Get the MAC address of the network interface.
@@ -74,6 +81,11 @@ public:
     /// Get the corresponding network interface description by index.
     ///
     char * STDCALL get_dev_desc_by_index(size_t dev_index);
+
+    ///
+    /// Get the corresponding network interface IP address by index.
+    ///
+    std::string STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index);
 
     ///
     /// Get the corresponding network interface name by index.

--- a/controller/lib/src/msvc/net_interface_imp.h
+++ b/controller/lib/src/msvc/net_interface_imp.h
@@ -96,12 +96,12 @@ public:
     ///
     /// Check whether ip_addr_str is a valid IP Address for a device.
     ///
-    bool STDCALL find_selected_interface_by_ip_address(size_t dev_index, char * ip_addr_str);
+    bool STDCALL does_interface_have_ip_address(size_t dev_index, char * ip_addr_str);
     
     ///
     /// Check whether mac_addr is the MAC Address for a device.
     ///
-    bool STDCALL find_selected_interface_by_mac_address(size_t dev_index, uint64_t mac_addr);
+    bool STDCALL does_interface_have_mac_address(size_t dev_index, uint64_t mac_addr);
 
     ///
     /// Get the corresponding network interface name by index.

--- a/controller/lib/src/osx/net_interface_imp.cpp
+++ b/controller/lib/src/osx/net_interface_imp.cpp
@@ -199,7 +199,7 @@ const char * STDCALL net_interface_imp::get_dev_ip_address_by_index(size_t dev_i
     return NULL;
 }
     
-bool STDCALL net_interface_imp::find_selected_interface_by_ip_address(size_t dev_index, char * ip_addr_str)
+bool STDCALL net_interface_imp::does_interface_have_ip_address(size_t dev_index, char * ip_addr_str)
 {
     if (dev_index < all_ip_addresses.size())
     {
@@ -211,7 +211,7 @@ bool STDCALL net_interface_imp::find_selected_interface_by_ip_address(size_t dev
     return false;
 }
     
-bool STDCALL net_interface_imp::find_selected_interface_by_mac_address(size_t dev_index, uint64_t mac_addr)
+bool STDCALL net_interface_imp::does_interface_have_mac_address(size_t dev_index, uint64_t mac_addr)
 {
     if (dev_index < all_mac_addresses.size())
     {

--- a/controller/lib/src/osx/net_interface_imp.cpp
+++ b/controller/lib/src/osx/net_interface_imp.cpp
@@ -64,6 +64,20 @@ net_interface_imp::net_interface_imp()
 
     for (dev = all_devs, total_devs = 0; dev; dev = dev->next)
     {
+        // store the valid IPv4 addresses associated with the device
+        std::vector<std::string> device_ip_addresses;
+        pcap_addr_t * dev_addr;
+        for (dev_addr = dev->addresses; dev_addr != NULL; dev_addr = dev_addr->next)
+        {
+            if (dev_addr->addr->sa_family == AF_INET && dev_addr->addr)
+            {
+                char ip_str[INET_ADDRSTRLEN] = {0};
+                inet_ntop(AF_INET, &((struct sockaddr_in *)dev_addr->addr)->sin_addr, ip_str, INET_ADDRSTRLEN);
+                device_ip_addresses.push_back(std::string(ip_str));
+            }
+        }
+        
+        all_ip_addresses.push_back(device_ip_addresses);
         total_devs++;
     }
 
@@ -89,6 +103,14 @@ uint32_t STDCALL net_interface_imp::devs_count()
 {
     return total_devs;
 }
+    
+size_t STDCALL net_interface_imp::device_ip_address_count(size_t dev_index)
+{
+    if (dev_index < all_ip_addresses.size())
+        return all_ip_addresses.at(dev_index).size();
+
+    return -1;
+}
 
 uint64_t net_interface_imp::mac_addr()
 {
@@ -110,7 +132,18 @@ char * STDCALL net_interface_imp::get_dev_desc_by_index(size_t dev_index)
 
     return dev->name;
 }
-
+    
+std::string STDCALL net_interface_imp::get_dev_ip_address_by_index(size_t dev_index, size_t ip_index)
+{
+    if (dev_index < all_ip_addresses.size())
+    {
+        if (ip_index < all_ip_addresses.at(dev_index).size())
+            return all_ip_addresses.at(dev_index).at(ip_index);
+    }
+    
+    return "";
+}
+    
 char * STDCALL net_interface_imp::get_dev_name_by_index(size_t dev_index)
 {
     return get_dev_desc_by_index(dev_index);

--- a/controller/lib/src/osx/net_interface_imp.cpp
+++ b/controller/lib/src/osx/net_interface_imp.cpp
@@ -133,15 +133,15 @@ char * STDCALL net_interface_imp::get_dev_desc_by_index(size_t dev_index)
     return dev->name;
 }
     
-std::string STDCALL net_interface_imp::get_dev_ip_address_by_index(size_t dev_index, size_t ip_index)
+const char * STDCALL net_interface_imp::get_dev_ip_address_by_index(size_t dev_index, size_t ip_index)
 {
     if (dev_index < all_ip_addresses.size())
     {
         if (ip_index < all_ip_addresses.at(dev_index).size())
-            return all_ip_addresses.at(dev_index).at(ip_index);
+            return all_ip_addresses.at(dev_index).at(ip_index).c_str();
     }
     
-    return "";
+    return NULL;
 }
     
 char * STDCALL net_interface_imp::get_dev_name_by_index(size_t dev_index)

--- a/controller/lib/src/osx/net_interface_imp.h
+++ b/controller/lib/src/osx/net_interface_imp.h
@@ -32,6 +32,7 @@
 #define HAVE_REMOTE
 
 #include <stdint.h>
+#include <vector>
 #include <pcap.h>
 #include "avdecc-lib_build.h"
 #include "net_interface.h"
@@ -41,6 +42,7 @@ namespace avdecc_lib
 class net_interface_imp : public virtual net_interface
 {
 private:
+    std::vector<std::vector<std::string> > all_ip_addresses;
     pcap_if_t * all_devs;
     pcap_if_t * dev;
     uint64_t mac;
@@ -66,6 +68,11 @@ public:
     /// Count the number of devices.
     ///
     uint32_t STDCALL devs_count();
+    
+    ///
+    /// Count the number of IP addresses for a device.
+    ///
+    size_t STDCALL device_ip_address_count(size_t dev_index);
 
     ///
     /// Get the MAC address of the network interface.
@@ -76,6 +83,11 @@ public:
     /// Get the corresponding network interface description by index.
     ///
     char * STDCALL get_dev_desc_by_index(size_t dev_index);
+    
+    ///
+    /// Get the corresponding network interface IP address by index.
+    ///
+    std::string STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index);
 
     ///
     /// Get the corresponding network interface name by index.

--- a/controller/lib/src/osx/net_interface_imp.h
+++ b/controller/lib/src/osx/net_interface_imp.h
@@ -103,12 +103,12 @@ public:
     ///
     /// Check whether ip_addr_str is a valid IP Address for a device.
     ///
-    bool STDCALL find_selected_interface_by_ip_address(size_t dev_index, char * ip_addr_str);
+    bool STDCALL does_interface_have_ip_address(size_t dev_index, char * ip_addr_str);
     
     ///
     /// Check whether mac_addr is the MAC Address for a device.
     ///
-    bool STDCALL find_selected_interface_by_mac_address(size_t dev_index, uint64_t mac_addr);
+    bool STDCALL does_interface_have_mac_address(size_t dev_index, uint64_t mac_addr);
 
     ///
     /// Get the corresponding network interface name by index.

--- a/controller/lib/src/osx/net_interface_imp.h
+++ b/controller/lib/src/osx/net_interface_imp.h
@@ -43,9 +43,10 @@ class net_interface_imp : public virtual net_interface
 {
 private:
     std::vector<std::vector<std::string> > all_ip_addresses;
+    std::vector<uint64_t> all_mac_addresses;
     pcap_if_t * all_devs;
     pcap_if_t * dev;
-    uint64_t mac;
+    uint64_t selected_dev_mac;
     uint32_t total_devs;
     pcap_t * pcap_interface;
     char err_buf[PCAP_ERRBUF_SIZE];
@@ -75,10 +76,20 @@ public:
     size_t STDCALL device_ip_address_count(size_t dev_index);
 
     ///
-    /// Get the MAC address of the network interface.
+    /// Get the MAC address of the selected network interface.
     ///
     uint64_t mac_addr();
 
+    ///
+    /// Find and store the MAC address string of a network interface.
+    ///
+    void find_and_store_device_mac_addr(char * dev_name);
+    
+    ///
+    /// Get the MAC address of a network interface.
+    ///
+    uint64_t STDCALL get_dev_mac_addr_by_index(size_t dev_index);
+    
     ///
     /// Get the corresponding network interface description by index.
     ///
@@ -88,6 +99,16 @@ public:
     /// Get the corresponding network interface IP address by index.
     ///
     const char * STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index);
+    
+    ///
+    /// Check whether ip_addr_str is a valid IP Address for a device.
+    ///
+    bool STDCALL find_selected_interface_by_ip_address(size_t dev_index, char * ip_addr_str);
+    
+    ///
+    /// Check whether mac_addr is the MAC Address for a device.
+    ///
+    bool STDCALL find_selected_interface_by_mac_address(size_t dev_index, uint64_t mac_addr);
 
     ///
     /// Get the corresponding network interface name by index.

--- a/controller/lib/src/osx/net_interface_imp.h
+++ b/controller/lib/src/osx/net_interface_imp.h
@@ -87,7 +87,7 @@ public:
     ///
     /// Get the corresponding network interface IP address by index.
     ///
-    std::string STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index);
+    const char * STDCALL get_dev_ip_address_by_index(size_t dev_index, size_t ip_index);
 
     ///
     /// Get the corresponding network interface name by index.

--- a/controller/lib/src/stream_output_descriptor_imp.h
+++ b/controller/lib/src/stream_output_descriptor_imp.h
@@ -72,6 +72,7 @@ public:
     int proc_get_stream_format_resp(void *& notification_id, const uint8_t * frame, size_t frame_len, int & status);
 
     int STDCALL send_set_stream_info_vlan_id_cmd(void * notification_id, uint16_t vlan_id);
+    int STDCALL send_set_stream_info_msrp_accumulated_latency_cmd(void * notification_id, uint32_t msrp_accumulated_latency);
     int proc_set_stream_info_resp(void *& notification_id, const uint8_t * frame, size_t frame_len, int & status);
 
     int STDCALL send_get_stream_info_cmd(void * notification_id);

--- a/controller/lib/src/version.h
+++ b/controller/lib/src/version.h
@@ -27,4 +27,4 @@
  * AVDECC Controller version
  */
 
-#define AVDECC_CONTROLLER_VERSION "v0.6.4"
+#define AVDECC_CONTROLLER_VERSION "v0.6.5"

--- a/controller/lib/src/version.h
+++ b/controller/lib/src/version.h
@@ -27,4 +27,4 @@
  * AVDECC Controller version
  */
 
-#define AVDECC_CONTROLLER_VERSION "v0.6.2"
+#define AVDECC_CONTROLLER_VERSION "v0.6.3"

--- a/controller/lib/src/version.h
+++ b/controller/lib/src/version.h
@@ -27,4 +27,4 @@
  * AVDECC Controller version
  */
 
-#define AVDECC_CONTROLLER_VERSION "v0.6.3"
+#define AVDECC_CONTROLLER_VERSION "v0.6.4"


### PR DESCRIPTION
Fix is to restart the inflight timer used to time out the wait for response if the end station sends an IN_PROGRESS status while erasing its image. Wait for the SUCCESS status before proceeding with the firmware update. 2) Parse AEM command response to retrieve the Status field, which is required to ensure the command returns to the prompt.
